### PR TITLE
fix: add 'safeguard' to the allowlist

### DIFF
--- a/src/library/allowlist.ts
+++ b/src/library/allowlist.ts
@@ -281,6 +281,7 @@ export const allowlist = [
   'rip',
   'round',
   'run',
+  'safeguard',
   'sanitise',
   'sanitize',
   'save',


### PR DESCRIPTION
Example: "feat: safeguard against missing environment variables when running the script"