### PR TITLE
fix: ignore casing

### DIFF
--- a/src/rules/subject-tense.ts
+++ b/src/rules/subject-tense.ts
@@ -27,7 +27,7 @@ export const subjectTense: Rule<RuleOptions> = (
     return [true]
   }
 
-  const { matches, offending } = ensureTense(subject, options)
+  const { matches, offending } = ensureTense(subject.toLowerCase(), options)
 
   const offenders = offending
     .map(({ lemma, tense }) => `${lemma}${tense === '' ? '' : ` - ${tense}`}`)


### PR DESCRIPTION
Since commitlint already comes with an option to enforce casing, this module should be agnostic to casing. It previously broke e.g. when using sentence casing.